### PR TITLE
Fix panic when input domain is an ICANN TLD.

### DIFF
--- a/publicsuffix/list.go
+++ b/publicsuffix/list.go
@@ -73,7 +73,7 @@ func getSuffix(domain string, icannOnly bool) (publicSuffix string, icann bool) 
 	s, suffix, wildcard := domain, len(domain), false
 	var dot int
 loop:
-	for ;; s = s[:dot] {
+	for {
 		dot = strings.LastIndex(s, ".")
 		if wildcard {
 			suffix = 1 + dot
@@ -91,6 +91,10 @@ loop:
 		// If we're only interested in ICANN suffixes, ignore any matches that are
 		// not ICANN.
 		if icannOnly && !icann {
+			if dot == -1 {
+				break
+			}
+			s = s[:dot]
 			continue
 		}
 		u >>= nodesBitsICANN
@@ -112,6 +116,7 @@ loop:
 		if dot == -1 {
 			break
 		}
+		s = s[:dot]
 	}
 	if icannOnly && suffix < len(domain) {
 		icann = true

--- a/publicsuffix/list_test.go
+++ b/publicsuffix/list_test.go
@@ -444,6 +444,9 @@ var icannTLDTestCases = []struct {
 
 	// Domain with a private public suffix should return the ICANN public suffix.
 	{"foo.compute-1.amazonaws.com", "com"},
+	// Domain equal to a private public suffix should return the ICANN public
+	// suffix.
+	{"cloudapp.net", "net"},
 }
 
 func TestICANNTLD(t *testing.T) {


### PR DESCRIPTION
My earlier refactoring put the `s = s[:dot]` in the loop iterator, neglecting the check at the end of the loop for dot != -1. This restores logic more similar to the original, fixing a panic for cases where input domain is exactly equal to an ICANN TLD.