### PR TITLE
Make publicsuffix's gen.go much faster

### DIFF
--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -30,6 +30,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/net/idna"
 )
@@ -98,7 +99,6 @@ var (
 	// letters are not allowed.
 	validSuffix = regexp.MustCompile(`^[a-z0-9_\!\*\-\.]+$`)
 
-	crush  = flag.Bool("crush", true, "make the generated node text as small as possible")
 	subset = flag.Bool("subset", false, "generate only a subset of the full table, for debugging")
 	url    = flag.String("url",
 		"https://publicsuffix.org/list/effective_tld_names.dat",
@@ -289,7 +289,7 @@ const numTLD = %d
 		childrenBitsWildcard, childrenBitsNodeType, childrenBitsHi, childrenBitsLo,
 		nodeTypeNormal, nodeTypeException, nodeTypeParentOnly, len(n.children))
 
-	text := makeText()
+	text := combineText(labelsList)
 	if text == "" {
 		return fmt.Errorf("internal error: makeText returned no text")
 	}
@@ -526,14 +526,78 @@ func wildcardStr(wildcard bool) string {
 	return " "
 }
 
-// makeText combines all the strings in labelsList to form one giant string.
-// If the crush flag is true, then overlapping strings will be merged: "arpa"
-// and "parliament" could yield "arparliament".
-func makeText() string {
-	if !*crush {
-		return strings.Join(labelsList, "")
+// affixMap maps from an affix (prefix or suffix) to a list of strings
+// containing that affix. The list of strings is represented as indexes into a
+// slice of strings stored elsewhere.
+type affixMap map[string][]int
+
+func (am affixMap) addAffix(affix string, num int) {
+	if am[affix] == nil {
+		am[affix] = []int{num}
+	} else {
+		am[affix] = append(am[affix], num)
+	}
+}
+
+// makeAffixMaps constructs a prefix map and a suffix map from a slice of
+// strings, containing all prefixes and suffixes of length affixLen.
+func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
+	suffixes = make(map[string][]int, len(ss))
+	prefixes = make(map[string][]int, len(ss))
+
+	for i, s := range ss {
+		if affixLen >= len(s) {
+			continue
+		}
+		// Take the length-N suffix and prefix of string i and add them to
+		// the corresponding affixMaps.
+		suffix := s[len(s)-affixLen:]
+		prefix := s[0:affixLen]
+		fmt.Fprintf(os.Stderr, "addString %d %s %s %s\n", affixLen, s, prefix, suffix)
+		suffixes.addAffix(suffix, i)
+		prefixes.addAffix(prefix, i)
 	}
 
+	return suffixes, prefixes
+}
+
+// crush finds matching (suffix, prefix) pairs of length `affixLen`, remove the
+// strings that contain them, and insert a hybrid string.
+// Note: This is not guaranteed to find all such pairs, or the optimal ordering
+// to combine them. Calling crush more than once for a given affixLen is likely
+// to yield additional improvements.
+// TODO: Make output deterministic by sorting map keys before interating on
+// them. Maybe. That could be a big performance hit.
+func crush(ss []string, affixLen int) []string {
+	suffixes, prefixes := makeAffixMaps(ss, affixLen)
+
+	for suffix, sufindexes := range suffixes {
+		for _, sufindex := range sufindexes {
+			if ss[sufindex] == "" {
+				continue
+			}
+			if prefindexes, ok := prefixes[suffix]; ok {
+				for _, prefindex := range prefindexes {
+					if prefindex == sufindex || ss[prefindex] == "" || ss[sufindex] == "" {
+						continue
+					}
+					fmt.Fprintf(os.Stderr, "looking at %d %s  %d %s  %s\n", sufindex, ss[sufindex], prefindex, ss[prefindex], suffix)
+					newString := ss[sufindex] + ss[prefindex][affixLen:]
+					fmt.Fprintf(os.Stderr, "%d-length: %s + %s -> %s\n", affixLen, ss[sufindex], ss[prefindex], newString)
+					ss[sufindex] = ""
+					ss[prefindex] = ""
+					ss = append(ss, newString)
+				}
+			}
+		}
+	}
+	return ss
+}
+
+// combineText combines all the strings in labelsList to form one giant string.
+// Overlapping strings will be merged: "arpa" and "parliament" could yield
+// "arparliament".
+func combineText(labelsList []string) string {
 	beforeLength := 0
 	for _, s := range labelsList {
 		beforeLength += len(s)
@@ -542,6 +606,8 @@ func makeText() string {
 	// Make a copy of labelsList.
 	ss := append(make([]string, 0, len(labelsList)), labelsList...)
 
+	begin := time.Now()
+	removedCount := 0
 	// Remove strings that are substrings of other strings.
 	for changed := true; changed; {
 		changed = false
@@ -551,96 +617,21 @@ func makeText() string {
 			}
 			for j, t := range ss {
 				if i != j && t != "" && strings.Contains(s, t) {
+					fmt.Fprintf(os.Stderr, "removing %s from %s\n", t, s)
 					changed = true
+					removedCount++
 					ss[j] = ""
 				}
 			}
 		}
 	}
+	fmt.Fprintf(os.Stderr, "removed %d substrings in %s\n", removedCount, time.Now().Sub(begin))
 
-	// Remove the empty strings.
-	sort.Strings(ss)
-	for len(ss) > 0 && ss[0] == "" {
-		ss = ss[1:]
-	}
-
-	addAffix := func(mp map[string][]int, affix string, num int) {
-		if mp[affix] == nil {
-			mp[affix] = []int{num}
-		} else {
-			mp[affix] = append(mp[affix], num)
-		}
-	}
-
-	// Find matching (suffix, prefix) pairs of length `affixLen`, remove the
-	// strings that contain them, and insert a hybrid string.
-	// TODO: Make output deterministic by sorting map keys before interating on
-	// them. Maybe. That could be a big performance hit.
-	crush := func(affixLen int) {
-		// For length L, suffixes[L] contains a map of all length-L suffixes to an
-		// index of a string containing that suffix.
-		suffixes := make(map[string][]int, len(ss))
-		prefixes := make(map[string][]int, len(ss))
-		enroll := func(s string, i int) {
-			if affixLen >= len(s) {
-				return
-			}
-			suffix := s[len(s)-affixLen:]
-			prefix := s[0:affixLen]
-			fmt.Fprintf(os.Stderr, "enroll %d %s %s %s\n", affixLen, s, prefix, suffix)
-			addAffix(suffixes, suffix, i)
-			addAffix(prefixes, prefix, i)
-		}
-
-		for i, s := range ss {
-			enroll(s, i)
-		}
-
-		// Join strings where one suffix matches another prefix, going from longest
-		// match to shortest. Burnt is a list of string indexes that are no longer
-		// usable because they have been joined.
-		// TODO: optimize away the 'burnt' table by double-checking that suffixes
-		// and prefixes still match before pulling trigger. That might also mean
-		// that we can unwrap the joinOne function and not have it return after
-		// every operation.
-		burnt := make(map[int]bool)
-		suffs := suffixes
-		prefs := prefixes
-		fmt.Fprintf(os.Stderr, "continue\n")
-		// Returns true if joined anything; false otherwise.
-		joinOne := func() bool {
-			for suffix, sufindexes := range suffs {
-				for _, sufindex := range sufindexes {
-					if burnt[sufindex] || ss[sufindex] == "" {
-						continue
-					}
-					if prefindexes, ok := prefs[suffix]; ok {
-						for _, prefindex := range prefindexes {
-							if burnt[prefindex] || prefindex == sufindex || ss[prefindex] == "" {
-								continue
-							}
-							fmt.Fprintf(os.Stderr, "looking at %d %s  %d %s  %s\n", sufindex, ss[sufindex], prefindex, ss[prefindex], suffix)
-							newString := ss[sufindex] + ss[prefindex][affixLen:]
-							fmt.Fprintf(os.Stderr, "%d-length: %s + %s -> %s\n", affixLen, ss[sufindex], ss[prefindex], newString)
-							ss[sufindex] = newString
-							ss[prefindex] = ""
-							burnt[sufindex] = true
-							burnt[prefindex] = true
-							return true
-						}
-					}
-				}
-			}
-			return false
-		}
-		for joinOne() {
-		}
-	}
 	for j := 15; j > 0; j-- {
-		crush(j)
-		crush(j)
-		crush(j)
-		crush(j)
+		ss = crush(ss, j)
+		ss = crush(ss, j)
+		ss = crush(ss, j)
+		ss = crush(ss, j)
 	}
 
 	text := strings.Join(ss, "")

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -539,33 +539,18 @@ func (am affixMap) addAffix(affix string, num int) {
 	}
 }
 
-// keys returns the keys of affixMap in sorted order.
-func (am affixMap) keys() []string {
-	ks := make([]string, 0, len(am))
-	for k := range am {
-		ks = append(ks, k)
-	}
-	sort.Strings(ks)
-	return ks
-}
-
-// makeAffixMaps constructs a prefix map and a suffix map from a slice of
-// strings, containing all prefixes and suffixes of length affixLen.
-func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
-	suffixes = make(map[string][]int, len(ss))
-	prefixes = make(map[string][]int, len(ss))
+// makePrefixMap constructs a prefix map from a slice of
+// strings, containing all prefixes of a given length.
+func makePrefixMap(ss []string, prefixLen int) affixMap {
+	prefixes := make(affixMap, len(ss))
 
 	for i, s := range ss {
-		if affixLen >= len(s) {
-			continue
+		if prefixLen < len(s) {
+			prefixes.addAffix(s[0:prefixLen], i)
 		}
-		suffix := s[len(s)-affixLen:]
-		prefix := s[0:affixLen]
-		suffixes.addAffix(suffix, i)
-		prefixes.addAffix(prefix, i)
 	}
 
-	return suffixes, prefixes
+	return prefixes
 }
 
 // crush finds matching (suffix, prefix) pairs of length `affixLen`, remove the
@@ -573,44 +558,43 @@ func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
 // Note: This is not guaranteed to find all such pairs, or the optimal ordering
 // to combine them. Calling crush more than once for a given affixLen is likely
 // to yield additional improvements.
-func crush(ss []string, affixLen int) []string {
-	suffixes, prefixes := makeAffixMaps(ss, affixLen)
+func crush(ss []string, affixLen int) bool {
+	changed := false
+	prefixes := makePrefixMap(ss, affixLen)
 
-	for _, suffix := range suffixes.keys() {
-		sufindexes := suffixes[suffix]
-		for _, sufindex := range sufindexes {
-			if ss[sufindex] == "" {
-				continue
-			}
-			if prefindexes, ok := prefixes[suffix]; ok {
-				for _, prefindex := range prefindexes {
-					if prefindex == sufindex || ss[prefindex] == "" || ss[sufindex] == "" {
-						continue
-					}
-					newString := ss[sufindex] + ss[prefindex][affixLen:]
-					if *v {
-						fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
-							affixLen, sufindex, prefindex, ss[sufindex], ss[prefindex], suffix)
-					}
-					ss[sufindex] = ""
-					ss[prefindex] = ""
-					ss = append(ss, newString)
+	for i, s := range ss {
+		if len(s) <= affixLen {
+			continue
+		}
+		suffix := s[len(s)-affixLen:]
+		if prefindexes, ok := prefixes[suffix]; ok {
+			for _, prefindex := range prefindexes {
+				if prefindex == i || ss[prefindex] == "" {
+					continue
 				}
+				if *v {
+					fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
+						affixLen, i, prefindex, ss[i], ss[prefindex], suffix)
+				}
+				ss[i] += ss[prefindex][affixLen:]
+				ss[prefindex] = ""
+				changed = true
+				break
 			}
 		}
 	}
-	return ss
+	return changed
 }
 
-type ByLength []string
+type byLength []string
 
-func (s ByLength) Len() int {
+func (s byLength) Len() int {
 	return len(s)
 }
-func (s ByLength) Swap(i, j int) {
+func (s byLength) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
-func (s ByLength) Less(i, j int) bool {
+func (s byLength) Less(i, j int) bool {
 	return len(s[i]) < len(s[j])
 }
 
@@ -622,7 +606,7 @@ func removeSubstrings(input []string) []string {
 
 	// Make a copy of input.
 	ss := append(make([]string, 0, len(input)), input...)
-	sort.Sort(ByLength(ss))
+	sort.Sort(byLength(ss))
 
 	for i, shortString := range ss {
 		// For each string, only consider strings higher than it in sort order, i.e.
@@ -634,6 +618,10 @@ func removeSubstrings(input []string) []string {
 				break
 			}
 		}
+	}
+	sort.Strings(ss)
+	for ss[0] == "" {
+		ss = ss[1:]
 	}
 	if *v {
 		fmt.Fprintf(os.Stderr, "removed %d substrings in %s\n", removedCount, time.Now().Sub(begin))
@@ -655,10 +643,8 @@ func combineText(labelsList []string) string {
 	// Length of the maximum overlap in (suffix, prefix) we expect.
 	const maxCommonAffix = 15
 	for j := maxCommonAffix; j > 0; j-- {
-		ss = crush(ss, j)
-		ss = crush(ss, j)
-		ss = crush(ss, j)
-		ss = crush(ss, j)
+		for crush(ss, j) {
+		}
 	}
 
 	text := strings.Join(ss, "")

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -12,6 +12,8 @@ package main
 //	go run gen.go -version "xxx"       >table.go
 //	go run gen.go -version "xxx" -test >table_test.go
 //
+// Pass -v to print verbose progress information.
+//
 // The version is derived from information found at
 // https://github.com/publicsuffix/list/commits/master/public_suffix_list.dat
 //
@@ -30,7 +32,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"golang.org/x/net/idna"
 )
@@ -99,8 +100,10 @@ var (
 	// letters are not allowed.
 	validSuffix = regexp.MustCompile(`^[a-z0-9_\!\*\-\.]+$`)
 
-	subset = flag.Bool("subset", false, "generate only a subset of the full table, for debugging")
-	url    = flag.String("url",
+	subset   = flag.Bool("subset", false, "generate only a subset of the full table, for debugging")
+	maxAffix = flag.Int("maxAffix", 15,
+		"Max of length of suffix / prefix to consider when crushing labels.")
+	url = flag.String("url",
 		"https://publicsuffix.org/list/effective_tld_names.dat",
 		"URL of the publicsuffix.org list. If empty, stdin is read instead")
 	v       = flag.Bool("v", false, "verbose output (to stderr)")
@@ -526,113 +529,6 @@ func wildcardStr(wildcard bool) string {
 	return " "
 }
 
-// affixMap maps from an affix (prefix or suffix) to a list of strings
-// containing that affix. The list of strings is represented as indexes into a
-// slice of strings stored elsewhere.
-type affixMap map[string][]int
-
-func (am affixMap) addAffix(affix string, num int) {
-	if am[affix] == nil {
-		am[affix] = []int{num}
-	} else {
-		am[affix] = append(am[affix], num)
-	}
-}
-
-// makePrefixMap constructs a prefix map from a slice of
-// strings, containing all prefixes of a given length.
-func makePrefixMap(ss []string, prefixLen int) affixMap {
-	prefixes := make(affixMap, len(ss))
-
-	for i, s := range ss {
-		if prefixLen < len(s) {
-			prefixes.addAffix(s[0:prefixLen], i)
-		}
-	}
-
-	return prefixes
-}
-
-func mergeLabel(ss []string, i, affixLen int, prefixes affixMap) {
-	s := ss[i]
-	suffix := s[len(s)-affixLen:]
-	if prefindexes, ok := prefixes[suffix]; ok {
-		for _, prefindex := range prefindexes {
-			if prefindex == i || ss[prefindex] == "" {
-				continue
-			}
-			if *v {
-				fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
-					affixLen, i, prefindex, ss[i], ss[prefindex], suffix)
-			}
-			ss[i] += ss[prefindex][affixLen:]
-			ss[prefindex] = ""
-			// ss[i] has a new suffix, so we want to merge again if possible.
-			mergeLabel(ss, i, affixLen, prefixes)
-			return
-		}
-	}
-}
-
-// crush finds matching (suffix, prefix) pairs of length `affixLen`, remove the
-// strings that contain them, and insert a hybrid string.
-// Note: This is not guaranteed to find all such pairs, or the optimal ordering
-// to combine them. Calling crush more than once for a given affixLen is likely
-// to yield additional improvements.
-func crush(ss []string, affixLen int) {
-	prefixes := makePrefixMap(ss, affixLen)
-
-	for i, s := range ss {
-		if len(s) <= affixLen {
-			continue
-		}
-		mergeLabel(ss, i, affixLen, prefixes)
-	}
-}
-
-type byLength []string
-
-func (s byLength) Len() int {
-	return len(s)
-}
-func (s byLength) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s byLength) Less(i, j int) bool {
-	return len(s[i]) < len(s[j])
-}
-
-// removeSubstrings returns a subset of its input with any strings removed
-// that are substrings of other strings in the output.
-func removeSubstrings(input []string) []string {
-	begin := time.Now()
-	removedCount := 0
-
-	// Make a copy of input.
-	ss := append(make([]string, 0, len(input)), input...)
-	sort.Sort(byLength(ss))
-
-	for i, shortString := range ss {
-		// For each string, only consider strings higher than it in sort order, i.e.
-		// of equal length or greater.
-		for _, longString := range ss[i+1:] {
-			if strings.Contains(longString, shortString) {
-				removedCount++
-				ss[i] = ""
-				break
-			}
-		}
-	}
-	sort.Strings(ss)
-	for ss[0] == "" {
-		ss = ss[1:]
-	}
-	if *v {
-		fmt.Fprintf(os.Stderr, "removed %d substrings in %s\n", removedCount, time.Now().Sub(begin))
-	}
-	return ss
-}
-
 // combineText combines all the strings in labelsList to form one giant string.
 // Overlapping strings will be merged: "arpa" and "parliament" could yield
 // "arparliament".
@@ -644,15 +540,101 @@ func combineText(labelsList []string) string {
 
 	ss := removeSubstrings(labelsList)
 
-	// Length of the maximum overlap in (suffix, prefix) we expect.
-	const maxCommonAffix = 15
-	for j := maxCommonAffix; j > 0; j-- {
-		crush(ss, j)
-	}
-
-	text := strings.Join(ss, "")
+	text := crush(ss)
 	if *v {
 		fmt.Fprintf(os.Stderr, "crushed %d bytes to become %d bytes\n", beforeLength, len(text))
 	}
 	return text
+}
+
+type byLength []string
+
+func (s byLength) Len() int           { return len(s) }
+func (s byLength) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byLength) Less(i, j int) bool { return len(s[i]) < len(s[j]) }
+
+// removeSubstrings returns a copy of its input with any strings removed
+// that are substrings of other provided strings.
+func removeSubstrings(input []string) []string {
+	// Make a copy of input.
+	ss := append(make([]string, 0, len(input)), input...)
+	sort.Sort(byLength(ss))
+
+	for i, shortString := range ss {
+		// For each string, only consider strings higher than it in sort order, i.e.
+		// of equal length or greater.
+		for _, longString := range ss[i+1:] {
+			if strings.Contains(longString, shortString) {
+				ss[i] = ""
+				break
+			}
+		}
+	}
+	sort.Strings(ss)
+	for len(ss) > 0 && ss[0] == "" {
+		ss = ss[1:]
+	}
+	return ss
+}
+
+// crush combines a list of strings, taking advantage of overlaps. It returns a
+// single string that contains each input string somewhere inside it.
+func crush(ss []string) string {
+	for affixLen := *maxAffix; affixLen > 0; affixLen-- {
+		prefixes := makePrefixMap(ss, affixLen)
+
+		for i, s := range ss {
+			if len(s) <= affixLen {
+				continue
+			}
+			mergeLabel(ss, i, affixLen, prefixes)
+		}
+	}
+
+	return strings.Join(ss, "")
+}
+
+func mergeLabel(ss []string, i, affixLen int, prefixes prefixMap) {
+	s := ss[i]
+	suffix := s[len(s)-affixLen:]
+	if prefindexes, ok := prefixes[suffix]; ok {
+		for _, j := range prefindexes {
+			// Empty strings mean "already used." Also avoid merging with self.
+			if ss[j] == "" || i == j {
+				continue
+			}
+			if *v {
+				fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
+					affixLen, i, j, ss[i], ss[j], suffix)
+			}
+			ss[i] += ss[j][affixLen:]
+			ss[j] = ""
+			// ss[i] has a new suffix, so merge again if possible.
+			mergeLabel(ss, i, affixLen, prefixes)
+			return
+		}
+	}
+}
+
+// prefixMap maps from a prefix to a list of strings containing that prefix. The
+// list of strings is represented as indexes into a slice of strings stored
+// elsewhere.
+type prefixMap map[string][]int
+
+// makePrefixMap constructs a prefixMap from a slice of strings
+func makePrefixMap(ss []string, prefixLen int) prefixMap {
+	prefixes := make(prefixMap, len(ss))
+
+	for i, s := range ss {
+		if prefixLen < len(s) {
+			affix := s[:prefixLen]
+			if prefixes[affix] == nil {
+				prefixes[affix] = []int{i}
+			} else {
+				prefixes[affix] = append(prefixes[affix], i)
+			}
+		}
+	}
+
+	return prefixes
 }

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -100,10 +100,10 @@ var (
 	// letters are not allowed.
 	validSuffix = regexp.MustCompile(`^[a-z0-9_\!\*\-\.]+$`)
 
-	subset   = flag.Bool("subset", false, "generate only a subset of the full table, for debugging")
 	maxAffix = flag.Int("maxAffix", 15,
 		"Max of length of suffix / prefix to consider when crushing labels.")
-	url = flag.String("url",
+	subset = flag.Bool("subset", false, "generate only a subset of the full table, for debugging")
+	url    = flag.String("url",
 		"https://publicsuffix.org/list/effective_tld_names.dat",
 		"URL of the publicsuffix.org list. If empty, stdin is read instead")
 	v       = flag.Bool("v", false, "verbose output (to stderr)")
@@ -570,6 +570,8 @@ func removeSubstrings(input []string) []string {
 			}
 		}
 	}
+
+	// Remove the empty strings.
 	sort.Strings(ss)
 	for len(ss) > 0 && ss[0] == "" {
 		ss = ss[1:]
@@ -578,7 +580,7 @@ func removeSubstrings(input []string) []string {
 }
 
 // crush combines a list of strings, taking advantage of overlaps. It returns a
-// single string that contains each input string somewhere inside it.
+// single string that contains each input string as a substring.
 func crush(ss []string) string {
 	for affixLen := *maxAffix; affixLen > 0; affixLen-- {
 		prefixes := makePrefixMap(ss, affixLen)

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -572,6 +572,10 @@ func makeText() string {
 		}
 	}
 
+	// Find matching (suffix, prefix) pairs of length `affixLen`, remove the
+	// strings that contain them, and insert a hybrid string.
+	// TODO: Make output deterministic by sorting map keys before interating on
+	// them. Maybe. That could be a big performance hit.
 	crush := func(affixLen int) {
 		// For length L, suffixes[L] contains a map of all length-L suffixes to an
 		// index of a string containing that suffix.
@@ -595,6 +599,10 @@ func makeText() string {
 		// Join strings where one suffix matches another prefix, going from longest
 		// match to shortest. Burnt is a list of string indexes that are no longer
 		// usable because they have been joined.
+		// TODO: optimize away the 'burnt' table by double-checking that suffixes
+		// and prefixes still match before pulling trigger. That might also mean
+		// that we can unwrap the joinOne function and not have it return after
+		// every operation.
 		burnt := make(map[int]bool)
 		suffs := suffixes
 		prefs := prefixes

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -564,40 +564,56 @@ func makeText() string {
 		ss = ss[1:]
 	}
 
-	// Join strings where one suffix matches another prefix.
-	for {
-		// Find best i, j, k such that ss[i][len-k:] == ss[j][:k],
-		// maximizing overlap length k.
-		besti := -1
-		bestj := -1
-		bestk := 0
-		for i, s := range ss {
-			if s == "" {
+	shortestWortwhile := 1
+	// For length L, suffixes[L] contains a map of all length-L suffixes to an
+	// index of a string containing that suffix.
+	suffixes := make([]map[string]int, 200)
+	for i, s := range ss {
+		for j := len(s) - 1; j > shortestWortwhile; j-- {
+			suffix := s[len(s)-j:]
+			if suffixes[j] == nil {
+				suffixes[j] = make(map[string]int)
+			}
+			fmt.Fprintf(os.Stderr, "suf %d %s %s = %d\n", j, s, suffix, i)
+			suffixes[j][suffix] = i
+		}
+	}
+
+	prefixes := make([]map[string]int, 200)
+	for i, s := range ss {
+		for j := len(s) - 1; j > shortestWortwhile; j-- {
+			prefix := s[0:j]
+			if prefixes[j] == nil {
+				prefixes[j] = make(map[string]int)
+			}
+			fmt.Fprintf(os.Stderr, "pref %d %s %s = %d\n", j, s, prefix, i)
+			prefixes[j][prefix] = i
+		}
+	}
+
+	// Join strings where one suffix matches another prefix, going from longest
+	// match to shortest. Burnt is a list of string indexes that are no longer
+	// usable because they have been joined.
+	burnt := make(map[int]bool)
+	for i := 15; i > shortestWortwhile; i-- {
+		suffs := suffixes[i]
+		prefs := prefixes[i]
+		for suffix, sufindex := range suffs {
+			if burnt[sufindex] {
 				continue
 			}
-			for j, t := range ss {
-				if i == j {
+			if prefindex, ok := prefs[suffix]; ok {
+				if burnt[prefindex] || prefindex == sufindex {
 					continue
 				}
-				for k := bestk + 1; k <= len(s) && k <= len(t); k++ {
-					if s[len(s)-k:] == t[:k] {
-						besti = i
-						bestj = j
-						bestk = k
-					}
-				}
+				newString := ss[sufindex] + ss[prefindex][i:]
+				fmt.Fprintf(os.Stderr, "%d-length: %s = %s -> %s\n", i, ss[sufindex], ss[prefindex], newString)
+				ss[sufindex] = newString
+				ss[prefindex] = ""
+				burnt[sufindex] = true
+				burnt[prefindex] = true
 			}
 		}
-		if bestk > 0 {
-			if *v {
-				fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d) out of (%4d,%4d): %q and %q\n",
-					bestk, besti, bestj, len(ss), len(ss), ss[besti], ss[bestj])
-			}
-			ss[besti] += ss[bestj][bestk:]
-			ss[bestj] = ""
-			continue
-		}
-		break
 	}
 
 	text := strings.Join(ss, "")

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -553,37 +553,41 @@ func makePrefixMap(ss []string, prefixLen int) affixMap {
 	return prefixes
 }
 
+func mergeLabel(ss []string, i, affixLen int, prefixes affixMap) {
+	s := ss[i]
+	suffix := s[len(s)-affixLen:]
+	if prefindexes, ok := prefixes[suffix]; ok {
+		for _, prefindex := range prefindexes {
+			if prefindex == i || ss[prefindex] == "" {
+				continue
+			}
+			if *v {
+				fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
+					affixLen, i, prefindex, ss[i], ss[prefindex], suffix)
+			}
+			ss[i] += ss[prefindex][affixLen:]
+			ss[prefindex] = ""
+			// ss[i] has a new suffix, so we want to merge again if possible.
+			mergeLabel(ss, i, affixLen, prefixes)
+			return
+		}
+	}
+}
+
 // crush finds matching (suffix, prefix) pairs of length `affixLen`, remove the
 // strings that contain them, and insert a hybrid string.
 // Note: This is not guaranteed to find all such pairs, or the optimal ordering
 // to combine them. Calling crush more than once for a given affixLen is likely
 // to yield additional improvements.
-func crush(ss []string, affixLen int) bool {
-	changed := false
+func crush(ss []string, affixLen int) {
 	prefixes := makePrefixMap(ss, affixLen)
 
 	for i, s := range ss {
 		if len(s) <= affixLen {
 			continue
 		}
-		suffix := s[len(s)-affixLen:]
-		if prefindexes, ok := prefixes[suffix]; ok {
-			for _, prefindex := range prefindexes {
-				if prefindex == i || ss[prefindex] == "" {
-					continue
-				}
-				if *v {
-					fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
-						affixLen, i, prefindex, ss[i], ss[prefindex], suffix)
-				}
-				ss[i] += ss[prefindex][affixLen:]
-				ss[prefindex] = ""
-				changed = true
-				break
-			}
-		}
+		mergeLabel(ss, i, affixLen, prefixes)
 	}
-	return changed
 }
 
 type byLength []string
@@ -643,8 +647,7 @@ func combineText(labelsList []string) string {
 	// Length of the maximum overlap in (suffix, prefix) we expect.
 	const maxCommonAffix = 15
 	for j := maxCommonAffix; j > 0; j-- {
-		for crush(ss, j) {
-		}
+		crush(ss, j)
 	}
 
 	text := strings.Join(ss, "")

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -539,6 +539,16 @@ func (am affixMap) addAffix(affix string, num int) {
 	}
 }
 
+// keys returns the keys of affixMap in sorted order.
+func (am affixMap) keys() []string {
+	ks := make([]string, 0, len(am))
+	for k := range am {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
 // makeAffixMaps constructs a prefix map and a suffix map from a slice of
 // strings, containing all prefixes and suffixes of length affixLen.
 func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
@@ -549,11 +559,8 @@ func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
 		if affixLen >= len(s) {
 			continue
 		}
-		// Take the length-N suffix and prefix of string i and add them to
-		// the corresponding affixMaps.
 		suffix := s[len(s)-affixLen:]
 		prefix := s[0:affixLen]
-		fmt.Fprintf(os.Stderr, "addString %d %s %s %s\n", affixLen, s, prefix, suffix)
 		suffixes.addAffix(suffix, i)
 		prefixes.addAffix(prefix, i)
 	}
@@ -566,12 +573,11 @@ func makeAffixMaps(ss []string, affixLen int) (suffixes, prefixes affixMap) {
 // Note: This is not guaranteed to find all such pairs, or the optimal ordering
 // to combine them. Calling crush more than once for a given affixLen is likely
 // to yield additional improvements.
-// TODO: Make output deterministic by sorting map keys before interating on
-// them. Maybe. That could be a big performance hit.
 func crush(ss []string, affixLen int) []string {
 	suffixes, prefixes := makeAffixMaps(ss, affixLen)
 
-	for suffix, sufindexes := range suffixes {
+	for _, suffix := range suffixes.keys() {
+		sufindexes := suffixes[suffix]
 		for _, sufindex := range sufindexes {
 			if ss[sufindex] == "" {
 				continue
@@ -581,15 +587,56 @@ func crush(ss []string, affixLen int) []string {
 					if prefindex == sufindex || ss[prefindex] == "" || ss[sufindex] == "" {
 						continue
 					}
-					fmt.Fprintf(os.Stderr, "looking at %d %s  %d %s  %s\n", sufindex, ss[sufindex], prefindex, ss[prefindex], suffix)
 					newString := ss[sufindex] + ss[prefindex][affixLen:]
-					fmt.Fprintf(os.Stderr, "%d-length: %s + %s -> %s\n", affixLen, ss[sufindex], ss[prefindex], newString)
+					if *v {
+						fmt.Fprintf(os.Stderr, "%d-length overlap at (%4d,%4d): %q and %q share %q\n",
+							affixLen, sufindex, prefindex, ss[sufindex], ss[prefindex], suffix)
+					}
 					ss[sufindex] = ""
 					ss[prefindex] = ""
 					ss = append(ss, newString)
 				}
 			}
 		}
+	}
+	return ss
+}
+
+type ByLength []string
+
+func (s ByLength) Len() int {
+	return len(s)
+}
+func (s ByLength) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s ByLength) Less(i, j int) bool {
+	return len(s[i]) < len(s[j])
+}
+
+// removeSubstrings returns a subset of its input with any strings removed
+// that are substrings of other strings in the output.
+func removeSubstrings(input []string) []string {
+	begin := time.Now()
+	removedCount := 0
+
+	// Make a copy of input.
+	ss := append(make([]string, 0, len(input)), input...)
+	sort.Sort(ByLength(ss))
+
+	for i, shortString := range ss {
+		// For each string, only consider strings higher than it in sort order, i.e.
+		// of equal length or greater.
+		for _, longString := range ss[i+1:] {
+			if strings.Contains(longString, shortString) {
+				removedCount++
+				ss[i] = ""
+				break
+			}
+		}
+	}
+	if *v {
+		fmt.Fprintf(os.Stderr, "removed %d substrings in %s\n", removedCount, time.Now().Sub(begin))
 	}
 	return ss
 }
@@ -603,31 +650,11 @@ func combineText(labelsList []string) string {
 		beforeLength += len(s)
 	}
 
-	// Make a copy of labelsList.
-	ss := append(make([]string, 0, len(labelsList)), labelsList...)
+	ss := removeSubstrings(labelsList)
 
-	begin := time.Now()
-	removedCount := 0
-	// Remove strings that are substrings of other strings.
-	for changed := true; changed; {
-		changed = false
-		for i, s := range ss {
-			if s == "" {
-				continue
-			}
-			for j, t := range ss {
-				if i != j && t != "" && strings.Contains(s, t) {
-					fmt.Fprintf(os.Stderr, "removing %s from %s\n", t, s)
-					changed = true
-					removedCount++
-					ss[j] = ""
-				}
-			}
-		}
-	}
-	fmt.Fprintf(os.Stderr, "removed %d substrings in %s\n", removedCount, time.Now().Sub(begin))
-
-	for j := 15; j > 0; j-- {
+	// Length of the maximum overlap in (suffix, prefix) we expect.
+	const maxCommonAffix = 15
+	for j := maxCommonAffix; j > 0; j-- {
 		ss = crush(ss, j)
 		ss = crush(ss, j)
 		ss = crush(ss, j)

--- a/publicsuffix/gen.go
+++ b/publicsuffix/gen.go
@@ -564,56 +564,75 @@ func makeText() string {
 		ss = ss[1:]
 	}
 
-	shortestWortwhile := 1
-	// For length L, suffixes[L] contains a map of all length-L suffixes to an
-	// index of a string containing that suffix.
-	suffixes := make([]map[string]int, 200)
-	for i, s := range ss {
-		for j := len(s) - 1; j > shortestWortwhile; j-- {
-			suffix := s[len(s)-j:]
-			if suffixes[j] == nil {
-				suffixes[j] = make(map[string]int)
-			}
-			fmt.Fprintf(os.Stderr, "suf %d %s %s = %d\n", j, s, suffix, i)
-			suffixes[j][suffix] = i
+	addAffix := func(mp map[string][]int, affix string, num int) {
+		if mp[affix] == nil {
+			mp[affix] = []int{num}
+		} else {
+			mp[affix] = append(mp[affix], num)
 		}
 	}
 
-	prefixes := make([]map[string]int, 200)
-	for i, s := range ss {
-		for j := len(s) - 1; j > shortestWortwhile; j-- {
-			prefix := s[0:j]
-			if prefixes[j] == nil {
-				prefixes[j] = make(map[string]int)
+	crush := func(affixLen int) {
+		// For length L, suffixes[L] contains a map of all length-L suffixes to an
+		// index of a string containing that suffix.
+		suffixes := make(map[string][]int, len(ss))
+		prefixes := make(map[string][]int, len(ss))
+		enroll := func(s string, i int) {
+			if affixLen >= len(s) {
+				return
 			}
-			fmt.Fprintf(os.Stderr, "pref %d %s %s = %d\n", j, s, prefix, i)
-			prefixes[j][prefix] = i
+			suffix := s[len(s)-affixLen:]
+			prefix := s[0:affixLen]
+			fmt.Fprintf(os.Stderr, "enroll %d %s %s %s\n", affixLen, s, prefix, suffix)
+			addAffix(suffixes, suffix, i)
+			addAffix(prefixes, prefix, i)
 		}
-	}
 
-	// Join strings where one suffix matches another prefix, going from longest
-	// match to shortest. Burnt is a list of string indexes that are no longer
-	// usable because they have been joined.
-	burnt := make(map[int]bool)
-	for i := 15; i > shortestWortwhile; i-- {
-		suffs := suffixes[i]
-		prefs := prefixes[i]
-		for suffix, sufindex := range suffs {
-			if burnt[sufindex] {
-				continue
-			}
-			if prefindex, ok := prefs[suffix]; ok {
-				if burnt[prefindex] || prefindex == sufindex {
-					continue
+		for i, s := range ss {
+			enroll(s, i)
+		}
+
+		// Join strings where one suffix matches another prefix, going from longest
+		// match to shortest. Burnt is a list of string indexes that are no longer
+		// usable because they have been joined.
+		burnt := make(map[int]bool)
+		suffs := suffixes
+		prefs := prefixes
+		fmt.Fprintf(os.Stderr, "continue\n")
+		// Returns true if joined anything; false otherwise.
+		joinOne := func() bool {
+			for suffix, sufindexes := range suffs {
+				for _, sufindex := range sufindexes {
+					if burnt[sufindex] || ss[sufindex] == "" {
+						continue
+					}
+					if prefindexes, ok := prefs[suffix]; ok {
+						for _, prefindex := range prefindexes {
+							if burnt[prefindex] || prefindex == sufindex || ss[prefindex] == "" {
+								continue
+							}
+							fmt.Fprintf(os.Stderr, "looking at %d %s  %d %s  %s\n", sufindex, ss[sufindex], prefindex, ss[prefindex], suffix)
+							newString := ss[sufindex] + ss[prefindex][affixLen:]
+							fmt.Fprintf(os.Stderr, "%d-length: %s + %s -> %s\n", affixLen, ss[sufindex], ss[prefindex], newString)
+							ss[sufindex] = newString
+							ss[prefindex] = ""
+							burnt[sufindex] = true
+							burnt[prefindex] = true
+							return true
+						}
+					}
 				}
-				newString := ss[sufindex] + ss[prefindex][i:]
-				fmt.Fprintf(os.Stderr, "%d-length: %s = %s -> %s\n", i, ss[sufindex], ss[prefindex], newString)
-				ss[sufindex] = newString
-				ss[prefindex] = ""
-				burnt[sufindex] = true
-				burnt[prefindex] = true
 			}
+			return false
 		}
+		for joinOne() {
+		}
+	}
+	for j := 15; j > 0; j-- {
+		crush(j)
+		crush(j)
+		crush(j)
+		crush(j)
 	}
 
 	text := strings.Join(ss, "")


### PR DESCRIPTION
Previously this took 20 minutes, now it takes 2-4 seconds.

Changes:
 - Iterate over prefix length, from longest to shortest.
 - Build a map of prefixes and reuse it to avoid one loop.
 - When removing simple substrings, first sort by length and only consider strings long enough to be worth checking. Saves 600ms out of 800ms.